### PR TITLE
[HCR-118] pnpm setup Job 추가

### DIFF
--- a/.github/workflows/customer-web-manual-release.yml
+++ b/.github/workflows/customer-web-manual-release.yml
@@ -135,6 +135,12 @@ jobs:
         with:
           node-version: 20
 
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Activate pnpm
+        run: corepack prepare pnpm@10 --activate
+
       - name: Install Vercel CLI
         run: npm install -g vercel@latest
 


### PR DESCRIPTION
## 📝작업 내용
<!-- 작업한 내용들 명시 -->

- `customer-web-manual-release` 워크플로우에서 `vercel build --prod` 실행 시 발생한 `spawn pnpm ENOENT` 이슈를 수정했습니다.
- `actions/setup-node` 이후 `corepack`/`pnpm` 활성화 단계를 추가했습니다.


<br/>

## 👀변경 사항
<!-- 팀원들이 알아야할 코드 , 설정, 구조등 변경을 명시 -->

| 파일 | 구분 | 변경 내용 | 기대 효과 |
|---|---|---|---|
| `.github/workflows/customer-web-manual-release.yml` | Step 추가 | `Enable Corepack` (`corepack enable`) | Runner에서 Corepack 사용 가능 |
| `.github/workflows/customer-web-manual-release.yml` | Step 추가 | `Activate pnpm` (`corepack prepare pnpm@10 --activate`) | `vercel build` 시 `pnpm` 실행 가능 (`ENOENT` 방지) |


<br/>

## 🎫 Jira Ticket
- Jira Ticket: HCR-118

<br/>

## #️⃣관련 이슈

- closes #31 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기타 개선사항**
  * 배포 파이프라인 구성을 최적화하여 패키지 매니저 호환성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->