### PR TITLE
[HSC-205] fix: central release resolve output masking

### DIFF
--- a/.github/workflows/central-release-orchestrator.yml
+++ b/.github/workflows/central-release-orchestrator.yml
@@ -188,6 +188,7 @@ jobs:
       deploy_customer_web: ${{ steps.resolve.outputs.deploy_customer_web }}
       deploy_worker: ${{ steps.resolve.outputs.deploy_worker }}
       deploy_counseling_analytics: ${{ steps.resolve.outputs.deploy_counseling_analytics }}
+      can_deploy_counseling_service: ${{ steps.resolve.outputs.can_deploy_counseling_service }}
     steps:
       - name: Resolve source + labels
         id: resolve
@@ -353,6 +354,14 @@ jobs:
             core.setOutput("deploy_customer_web", deployLabels.includes("deploy:customer-web") ? "true" : "false");
             core.setOutput("deploy_worker", deployLabels.includes("deploy:worker") ? "true" : "false");
             core.setOutput("deploy_counseling_analytics", deployLabels.includes("deploy:counseling-analytics") ? "true" : "false");
+            core.setOutput(
+              "can_deploy_counseling_service",
+              (
+                process.env.COUNSELING_ANALYTICS_CLUSTER_NAME &&
+                process.env.COUNSELING_ANALYTICS_SERVICE_NAME &&
+                (process.env.COUNSELING_ANALYTICS_TASK_DEFINITION_ARN || process.env.COUNSELING_ANALYTICS_TASK_DEFINITION_FAMILY)
+              ) ? "true" : "false"
+            );
 
   create-tag:
     runs-on: ubuntu-latest
@@ -830,6 +839,11 @@ jobs:
           REPO="${REGISTRY}/${COUNSELING_ANALYTICS_REPOSITORY}"
           IMAGE_TAG="counseling-analytics-${VERSION_TAG}"
 
+          if ! aws ecr describe-repositories --repository-names "${COUNSELING_ANALYTICS_REPOSITORY}" >/dev/null 2>&1; then
+            echo "Create ECR repository: ${COUNSELING_ANALYTICS_REPOSITORY}"
+            aws ecr create-repository --repository-name "${COUNSELING_ANALYTICS_REPOSITORY}" >/dev/null
+          fi
+
           if aws ecr describe-images --repository-name "${COUNSELING_ANALYTICS_REPOSITORY}" --image-ids imageTag="${IMAGE_TAG}" >/dev/null 2>&1; then
             echo "Skip push: ${REPO}:${IMAGE_TAG} already exists."
           else
@@ -1160,6 +1174,7 @@ jobs:
     if: |
       always() &&
       needs.resolve-context.outputs.deploy_counseling_analytics == 'true' &&
+      needs.resolve-context.outputs.can_deploy_counseling_service == 'true' &&
       needs.resolve-context.result == 'success' &&
       needs.create-tag.result == 'success' &&
       needs.build-and-push-counseling-analytics.result == 'success' &&


### PR DESCRIPTION
## Summary
- replace plain resolve outputs with safe outputs (base64 + boolean)
- update downstream jobs and conditions to avoid masked-output dependent checks
- add counseling ECR bootstrap and service-deploy gating output

## Why
- GitHub output masking dropped resolve outputs and downstream jobs were skipped.

## Validation
- workflow_dispatch run on this branch: https://github.com/one-year-gap/infra/actions/runs/22732399758
- resolve-context no longer shows skip output masking warnings and downstream jobs execute


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 배포 워크플로우 인프라 최적화: 출력 형식 및 배포 조건 처리 방식을 개선하여 배포 프로세스의 안정성과 명확성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->