### PR TITLE
[HCR-245] counseling 앱별 namespaced release tag 지원

### DIFF
--- a/.github/workflows/central-release-orchestrator.yml
+++ b/.github/workflows/central-release-orchestrator.yml
@@ -184,6 +184,7 @@ jobs:
       source_sha: ${{ steps.resolve.outputs.source_sha }}
       release_label: ${{ steps.resolve.outputs.release_label }}
       release_level: ${{ steps.resolve.outputs.release_level }}
+      tag_namespace: ${{ steps.resolve.outputs.tag_namespace }}
       deploy_labels_csv: ${{ steps.resolve.outputs.deploy_labels_csv }}
       deploy_api_server: ${{ steps.resolve.outputs.deploy_api_server }}
       deploy_admin_web: ${{ steps.resolve.outputs.deploy_admin_web }}
@@ -232,6 +233,42 @@ jobs:
                 .split(",")
                 .map(v => v.trim())
                 .filter(Boolean);
+            }
+
+            function resolveTagNamespace(repoName, deployLabels) {
+              if (repoName !== "counseling-analytics") {
+                return "";
+              }
+
+              const hasLegacyNamespace = deployLabels.includes("deploy:counseling-analytics");
+              const hasRecommendationNamespace = deployLabels.some(label =>
+                label === "deploy:recommendation-server" || label === "deploy:recommendation-realtime"
+              );
+              const hasAnalysisNamespace = deployLabels.some(label =>
+                label === "deploy:analysis-server" || label === "deploy:counseling-batch"
+              );
+
+              const namespaceCount = [
+                hasLegacyNamespace,
+                hasRecommendationNamespace,
+                hasAnalysisNamespace,
+              ].filter(Boolean).length;
+
+              if (namespaceCount !== 1) {
+                throw new Error(
+                  "counseling-analytics release must resolve to exactly one namespace. " +
+                    "use one of deploy:analysis-server/deploy:counseling-batch, " +
+                    "deploy:recommendation-server/deploy:recommendation-realtime, or deploy:counseling-analytics"
+                );
+              }
+
+              if (hasRecommendationNamespace) {
+                return "recommendation-server";
+              }
+              if (hasAnalysisNamespace) {
+                return "analysis-server";
+              }
+              return "counseling-analytics";
             }
 
             let sourceRepo;
@@ -355,11 +392,13 @@ jobs:
             }
 
             const releaseLevel = releaseLabel.replace("release:", "");
+            const tagNamespace = resolveTagNamespace(repo, deployLabels);
 
             core.setOutput("source_repo_name", repo);
             core.setOutput("source_sha",        sourceSha || "");
             core.setOutput("release_label",     releaseLabel);
             core.setOutput("release_level",     releaseLevel);
+            core.setOutput("tag_namespace",     tagNamespace);
             core.setOutput("deploy_labels_csv", deployLabels.join(","));
             core.setOutput("deploy_api_server", deployLabels.includes("deploy:api-server") ? "true" : "false");
             core.setOutput("deploy_admin_web", deployLabels.includes("deploy:admin-web") ? "true" : "false");
@@ -470,6 +509,7 @@ jobs:
         shell: bash
         env:
           RELEASE_LEVEL: ${{ needs.resolve-context.outputs.release_level }}
+          TAG_NAMESPACE: ${{ needs.resolve-context.outputs.tag_namespace }}
           SOURCE_SHA:    ${{ needs.resolve-context.outputs.source_sha }}
         run: |
           set -euo pipefail
@@ -489,12 +529,36 @@ jobs:
             exit 1
           fi
 
-          LATEST_TAG="$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n1)"
-          if [ -z "$LATEST_TAG" ]; then
-            LATEST_TAG="v0.0.0"
+          LEGACY_TAG_PATTERN='v[0-9]*.[0-9]*.[0-9]*'
+          if [ -n "${TAG_NAMESPACE:-}" ]; then
+            TAG_PATTERN="${TAG_NAMESPACE}-v[0-9]*.[0-9]*.[0-9]*"
+            LATEST_TAG="$(git tag -l "$TAG_PATTERN" --sort=-v:refname | head -n1)"
+
+            # analysis-server inherits the legacy counseling-analytics version line.
+            if [ -z "$LATEST_TAG" ]; then
+              case "$TAG_NAMESPACE" in
+                analysis-server|counseling-analytics)
+                  LATEST_TAG="$(git tag -l "$LEGACY_TAG_PATTERN" --sort=-v:refname | head -n1)"
+                  ;;
+              esac
+            fi
+
+            if [ -z "$LATEST_TAG" ]; then
+              LATEST_TAG="${TAG_NAMESPACE}-v0.0.0"
+            fi
+
+            BASE="${LATEST_TAG##*-v}"
+            if [ "$BASE" = "$LATEST_TAG" ]; then
+              BASE="${LATEST_TAG#v}"
+            fi
+          else
+            LATEST_TAG="$(git tag -l "$LEGACY_TAG_PATTERN" --sort=-v:refname | head -n1)"
+            if [ -z "$LATEST_TAG" ]; then
+              LATEST_TAG="v0.0.0"
+            fi
+            BASE="${LATEST_TAG#v}"
           fi
 
-          BASE="${LATEST_TAG#v}"
           IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE"
 
           case "$RELEASE_LEVEL" in
@@ -507,7 +571,11 @@ jobs:
               ;;
           esac
 
-          NEXT_TAG="v${MAJOR}.${MINOR}.${PATCH}"
+          if [ -n "${TAG_NAMESPACE:-}" ]; then
+            NEXT_TAG="${TAG_NAMESPACE}-v${MAJOR}.${MINOR}.${PATCH}"
+          else
+            NEXT_TAG="v${MAJOR}.${MINOR}.${PATCH}"
+          fi
 
           if git rev-parse "$NEXT_TAG" >/dev/null 2>&1; then
             echo "::error::Tag already exists: $NEXT_TAG" >&2
@@ -535,6 +603,7 @@ jobs:
           VERSION_TAG:        ${{ needs.create-tag.outputs.version_tag }}
           TARGET_SHA:         ${{ needs.create-tag.outputs.target_sha }}
           RELEASE_LABEL:      ${{ needs.resolve-context.outputs.release_label }}
+          TAG_NAMESPACE:      ${{ needs.resolve-context.outputs.tag_namespace }}
           DEPLOY_LABELS_CSV:  ${{ needs.resolve-context.outputs.deploy_labels_csv }}
         with:
           github-token: ${{ secrets.CENTRAL_REPO_TOKEN }}
@@ -551,6 +620,7 @@ jobs:
             const tag            = process.env.VERSION_TAG;
             const targetSha      = process.env.TARGET_SHA;
             const releaseLabel   = process.env.RELEASE_LABEL;
+            const tagNamespace   = String(process.env.TAG_NAMESPACE || "").trim();
             const deployLabels   = String(process.env.DEPLOY_LABELS_CSV || "")
               .split(",")
               .map(v => v.trim())
@@ -570,8 +640,8 @@ jobs:
             }
 
             const header = [
-              
               `release-label: ${releaseLabel}`,
+              `tag-namespace: ${tagNamespace || "global"}`,
               `deploy-labels: ${deployLabels.join(", ") || "none"}`
             ].join("\n");
 


### PR DESCRIPTION
## 📝작업 내용
<!-- 작업한 내용들 명시 -->
- `counseling-analytics` 릴리즈 태그를 전역 `vX.Y.Z` 방식에서 앱별 namespace 기반으로 계산할 수 있도록 `central-release-orchestrator`를 수정했습니다.
- deploy label 조합에 따라 `analysis-server`, `recommendation-server`, `counseling-analytics` 중 정확히 하나의 태그 namespace를 해석하도록 추가했습니다.
- `analysis-server`는 기존 글로벌 태그 라인을 이어받아 다음 버전을 계산하고, `recommendation-server`는 신규 namespace 기준으로 별도 버전 라인을 시작하도록 구성했습니다.
- GitHub Release 본문에도 `tag-namespace` 정보를 포함하도록 변경했습니다.

<br/>

## 👀변경 사항
<!-- 팀원들이 알아야할 코드 , 설정, 구조등 변경을 명시 -->

| 구분 | 변경 내용 | 비고 |
| --- | --- | --- |
| 릴리즈 컨텍스트 해석 | `resolve-context` 단계에서 `tag_namespace`를 추가로 계산하도록 변경 | `counseling-analytics` 전용 |
| namespace 규칙 | `deploy:analysis-server`, `deploy:counseling-batch` → `analysis-server` | 분석 배치 계열 |
| namespace 규칙 | `deploy:recommendation-server`, `deploy:recommendation-realtime` → `recommendation-server` | 추천 실시간 계열 |
| legacy 호환 | `deploy:counseling-analytics`는 `counseling-analytics` namespace로 처리 | 구 배포 라벨 호환 유지 |
| 검증 강화 | 서로 다른 앱 namespace 라벨이 동시에 들어오면 workflow 단계에서 실패 처리 | 잘못된 릴리즈 방지 |
| 태그 계산 | namespace가 있으면 `${namespace}-vX.Y.Z` 패턴으로 최신 태그 조회 및 증가 | 예: `analysis-server-v0.0.5` |
| 버전 이관 | `analysis-server`는 기존 `v0.0.4`를 이어받아 `analysis-server-v0.0.5`부터 시작 | 레거시 글로벌 태그 계승 |
| 신규 라인 | `recommendation-server`는 `recommendation-server-v0.0.1`부터 시작 | 추천 앱 독립 버전 시작 |
| 릴리즈 메타데이터 | GitHub Release body header에 `tag-namespace` 추가 | 추적성 보강 |


<br/>

## 🎫 Jira Ticket
- Jira Ticket: HCR-245

<br/>

## #️⃣관련 이슈

- closes #58 

<br/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 릴리스 워크플로우 개선을 통한 태그 네임스페이스 체계화
  * 릴리스 메타데이터 확장으로 서비스별 버전 식별성 강화
  * CI/CD 배포 프로세스의 안정성과 추적성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->